### PR TITLE
Fix issues when using mysqli

### DIFF
--- a/PhpRbac/database/database.config
+++ b/PhpRbac/database/database.config
@@ -8,5 +8,6 @@ $dbname=__DIR__."/phprbac.sqlite3";
 
 $adapter="pdo_sqlite";
 // $adapter="pdo_mysql";
+// $adapter="mysqli";
 
 $table_prefix = "phprbac_";

--- a/PhpRbac/src/PhpRbac/core/setup.php
+++ b/PhpRbac/src/PhpRbac/core/setup.php
@@ -25,7 +25,7 @@ elseif ($adapter=="pdo_sqlite")
 else # default to mysqli 
 {
 	jf::$Db=new mysqli($host,$user,$pass,$dbname);
-	if(jf::$Db->connect_errno==1049);
+	if(jf::$Db->connect_errno==1049)
 		InstallMySQLi($host,$user,$pass,$dbname);
 }
 function GetSQLs($dbms)


### PR DESCRIPTION
1. $adapter variable required also for mysqli
2. The database is always reset unless a ; is removed
