### PR TITLE
Added option to pass database through constructor

### DIFF
--- a/PhpRbac/src/PhpRbac/Rbac.php
+++ b/PhpRbac/src/PhpRbac/Rbac.php
@@ -13,9 +13,15 @@ use \Jf;
  */
 class Rbac
 {
-    public function __construct($unit_test = '')
+    public function __construct($unit_test = '', $db_config_params=null)
     {
-        if ((string) $unit_test === 'unit_test') {
+        if (! is_null($db_config_params)) {
+            foreach (array('host', 'user', 'pass', 'dbname', 'adapter', 'tablePrefix') as $db_config_param) {
+               if (isset($db_config_params[$db_config_param])) {
+                   $$db_config_param = (string) $db_config_params[$db_config_param];
+               }                 
+            }
+        } else if ((string) $unit_test === 'unit_test') {
             require_once dirname(dirname(__DIR__)) . '/tests/database/database.config';
         } else {
             require_once dirname(dirname(__DIR__)) . '/database/database.config';


### PR DESCRIPTION
Some applications could benefit from the option of being able to define
the Rbac storage database programatically. This is true for applications
that that might switch between different Rbac rule sets, or applications
that have some centralised configuration mechanism (such as LDAP).

Database configuration that's normally stored in database.config, can be
passed to the Rbac class constructor as an array. The following array
keys are recognised, 'host', 'user', 'pass', 'dbname', 'adapter',
'tablePrefix'. All other keys will be ignored. Values are typecast to
strings.

It's important to note that even though this change allows you to load
rules dynamically, it _DOES NOT_ allow you to have two different Rbac
instances at the same time, due to the extensive use of static members
in the Jf class. This should be the focus of a later patch.

The change is backward compatible, if no connection details are passed
to the constructor, it will fall back on the usuall database.config
file.
