### PR TITLE
Optionally pass the database configuration parameters on Rbac constructo...

### DIFF
--- a/PhpRbac/src/PhpRbac/Rbac.php
+++ b/PhpRbac/src/PhpRbac/Rbac.php
@@ -13,10 +13,23 @@ use \Jf;
  */
 class Rbac
 {
-    public function __construct($unit_test = '')
+    public function __construct($unit_test = '', array $databaseConfig = array())
     {
         if ((string) $unit_test === 'unit_test') {
             require_once dirname(dirname(__DIR__)) . '/tests/database/database.config';
+        } elseif (!empty($databaseConfig)) {
+            $databaseConfig = $databaseConfig + array(
+                'host' => 'localhost',
+                'user' => 'root',
+                'pass' => '',
+                'dbname' => dirname(dirname(__DIR__)) . "/phprbac.sqlite3",
+                'adapter' => 'pdo_sqlite', // 'pdo_sqlite', 'pdo_mysql', 'mysqli'
+                'tablePrefix' => 'phprbac_'
+            );
+            
+            extract($databaseConfig);
+            unset($databaseConfig);
+                    
         } else {
             require_once dirname(dirname(__DIR__)) . '/database/database.config';
         }


### PR DESCRIPTION
Possibility to programmatically pass on the database configuration.

Just pass the parameters into the constructor, falls back to default configuration variables (same as those in database.config file).

This change was made with regard of compatibility with existing version.
