### PR TITLE
Constructor to support custom db config dir

### DIFF
--- a/PhpRbac/src/PhpRbac/Rbac.php
+++ b/PhpRbac/src/PhpRbac/Rbac.php
@@ -13,10 +13,12 @@ use \Jf;
  */
 class Rbac
 {
-    public function __construct($unit_test = '')
+    public function __construct($unit_test = '', $config_dir=null)
     {
         if ((string) $unit_test === 'unit_test') {
             require_once dirname(dirname(__DIR__)) . '/tests/database/database.config';
+        } elseif(isset($config_dir)) {    
+            require_once $config_dir;
         } else {
             require_once dirname(dirname(__DIR__)) . '/database/database.config';
         }


### PR DESCRIPTION
Second suggestion to support a custom config directory, a second parameter that takes in a directory and is ignored if not used.  Wasn't sure about adding validation intentionally left that out, at minimum should probably check if the file exists and throw an exception if it doesn't.
