### PR TITLE
fix bug descendant or children failed on mysql5.7

### DIFF
--- a/PhpRbac/src/PhpRbac/core/lib/nestedset/full.php
+++ b/PhpRbac/src/PhpRbac/core/lib/nestedset/full.php
@@ -227,7 +227,7 @@ class FullNestedSet extends BaseNestedSet implements ExtendedNestedSet
     function descendantsConditional($AbsoluteDepths=false,$ConditionString,$Rest=null)
     {
         if (!$AbsoluteDepths)
-            $DepthConcat="- (sub_tree.innerDepth )";
+            $DepthConcat="- (GROUP_CONCAT(sub_tree.innerDepth) )";
         $Arguments=func_get_args();
         array_shift($Arguments);
         array_shift($Arguments); //second argument, $AbsoluteDepths
@@ -271,7 +271,7 @@ class FullNestedSet extends BaseNestedSet implements ExtendedNestedSet
         $Arguments=func_get_args();
         array_shift($Arguments);
         $Query="
-            SELECT node.*, (COUNT(parent.{$this->id()})-1 - (sub_tree.innerDepth )) AS Depth
+            SELECT node.*, (COUNT(parent.{$this->id()})-1 - (GROUP_CONCAT(sub_tree.innerDepth) )) AS Depth
             FROM {$this->table()} AS node,
             	{$this->table()} AS parent,
             	{$this->table()} AS sub_parent,


### PR DESCRIPTION
Add group_concat aggregrate function to fix bug when get descendant or children query execute failed due to mysql 5.7 default sql_mod=only_full_group_by