### PR TITLE
Recurse check

### DIFF
--- a/PhpRbac/src/PhpRbac/Rbac.php
+++ b/PhpRbac/src/PhpRbac/Rbac.php
@@ -33,9 +33,9 @@ class Rbac
         return Jf::$Rbac->assign($role, $permission);
     }
 
-    public function check($permission, $user_id)
+    public function check($permission, $user_id, $recurse = false)
     {
-        return Jf::$Rbac->check($permission, $user_id);
+        return Jf::$Rbac->check($permission, $user_id, $recurse);
     }
 
     public function enforce($permission, $user_id)

--- a/PhpRbac/src/PhpRbac/Rbac.php
+++ b/PhpRbac/src/PhpRbac/Rbac.php
@@ -38,9 +38,9 @@ class Rbac
         return Jf::$Rbac->check($permission, $user_id, $recurse);
     }
 
-    public function enforce($permission, $user_id)
+    public function enforce($permission, $user_id, $recurse = false)
     {
-        return Jf::$Rbac->enforce($permission, $user_id);
+        return Jf::$Rbac->enforce($permission, $user_id, $recurse);
     }
 
     public function reset($ensure = false)

--- a/PhpRbac/src/PhpRbac/core/lib/rbac.php
+++ b/PhpRbac/src/PhpRbac/core/lib/rbac.php
@@ -644,14 +644,18 @@ class RbacManager extends JModel
     *
     * @param integer $UserID
     *
+    * @param bool $Recurse
+    *          Use when $Permission is a path, allow system to recursively 
+    *          find permission
+    *
     * @throws RbacUserNotProvidedException
     */
-	function enforce($Permission, $UserID = null)
+	function enforce($Permission, $UserID = null, $Recurse = false)
 	{
 	if ($UserID === null)
                 throw new \RbacUserNotProvidedException ("\$UserID is a required argument.");
 
-		if (! $this->check($Permission, $UserID)) {
+		if (! $this->check($Permission, $UserID, $Recurse)) {
             header('HTTP/1.1 403 Forbidden');
             die("<strong>Forbidden</strong>: You do not have permission to access this resource.");
         }

--- a/PhpRbac/src/PhpRbac/core/lib/rbac.php
+++ b/PhpRbac/src/PhpRbac/core/lib/rbac.php
@@ -569,12 +569,15 @@ class RbacManager extends JModel
      *        	containing a number)
      * @param string|integer $UserID
      *        	User ID of a user
+     * @param bool $Recurse
+     *          Use when $Permission is a path, allow system to recursively 
+     *          find permission
      *
      * @throws RbacPermissionNotFoundException
      * @throws RbacUserNotProvidedException
      * @return boolean
      */
-    function check($Permission, $UserID = null)
+    function check($Permission, $UserID = null, $Recurse = false)
     {
         if ($UserID === null)
             throw new \RbacUserNotProvidedException ("\$UserID is a required argument.");
@@ -586,10 +589,15 @@ class RbacManager extends JModel
         }
         else
         {
-            if (substr ( $Permission, 0, 1 ) == "/")
+            if (substr ( $Permission, 0, 1 ) == "/") {
                 $PermissionID = $this->Permissions->pathId ( $Permission );
-            else
+                if ($PermissionID === null && $Recurse) {
+                    $newPath = implode('/', explode('/', $Permission, -1));
+                    return $this->check($newPath, $UserID, true);
+                }
+            } else {
                 $PermissionID = $this->Permissions->titleId ( $Permission );
+            }
         }
 
         // if invalid, throw exception

--- a/PhpRbac/tests/src/RbacManagerTest.php
+++ b/PhpRbac/tests/src/RbacManagerTest.php
@@ -270,6 +270,22 @@ class RbacManagerTest extends \RbacSetup
         $this->assertTrue($result);
     }
 
+    public function testManagerEnforceRecursivePath()
+    {
+        self::$rbac->Permissions->addPath('/permissions_1/permissions_2');
+        $perm_id_1 = self::$rbac->Permissions->pathId('/permissions_1/permissions_2');
+        
+        self::$rbac->Roles->addPath('/roles_1/roles_2/roles_3');
+        $role_id_1 = self::$rbac->Roles->pathId('/roles_1/roles_2/roles_3');
+        
+        self::$rbac->Roles->assign($role_id_1, $perm_id_1);
+        self::$rbac->Users->assign($role_id_1, 5);
+        
+        $result = self::$rbac->enforce('/permissions_1/permissions_2/permissions_3', 5, true);
+        
+        $this->assertTrue($result);
+    }
+    
     /**
      * @expectedException RbacUserNotProvidedException
      */

--- a/PhpRbac/tests/src/RbacManagerTest.php
+++ b/PhpRbac/tests/src/RbacManagerTest.php
@@ -141,12 +141,12 @@ class RbacManagerTest extends \RbacSetup
     public function testManagerCheckPath()
     {
         self::$rbac->Permissions->addPath('/permissions_1/permissions_2/permissions_3');
-        $perm_id_1 = self::$rbac->Permissions->pathId('/permissions_1/permissions_2/permissions_3');
+        $perm_id_1 = self::$rbac->Permissions->pathId('/permissions_1/permissions_2');
 
         self::$rbac->Roles->addPath('/roles_1/roles_2/roles_3');
         $role_id_1 = self::$rbac->Roles->pathId('/roles_1/roles_2/roles_3');
 
-        self::$rbac->Roles->assign($role_id_1, 3);
+        self::$rbac->Roles->assign($role_id_1, $perm_id_1);
         self::$rbac->Users->assign($role_id_1, 5);
 
         $result = self::$rbac->check('/permissions_1/permissions_2', 5);
@@ -222,12 +222,12 @@ class RbacManagerTest extends \RbacSetup
     public function testManagerEnforcePath()
     {
         self::$rbac->Permissions->addPath('/permissions_1/permissions_2/permissions_3');
-        $perm_id_1 = self::$rbac->Permissions->pathId('/permissions_1/permissions_2/permissions_3');
+        $perm_id_1 = self::$rbac->Permissions->pathId('/permissions_1/permissions_2');
 
         self::$rbac->Roles->addPath('/roles_1/roles_2/roles_3');
         $role_id_1 = self::$rbac->Roles->pathId('/roles_1/roles_2/roles_3');
 
-        self::$rbac->Roles->assign($role_id_1, 3);
+        self::$rbac->Roles->assign($role_id_1, $perm_id_1);
         self::$rbac->Users->assign($role_id_1, 5);
 
         $result = self::$rbac->enforce('/permissions_1/permissions_2', 5);

--- a/PhpRbac/tests/src/RbacManagerTest.php
+++ b/PhpRbac/tests/src/RbacManagerTest.php
@@ -154,6 +154,41 @@ class RbacManagerTest extends \RbacSetup
         $this->assertTrue($result);
     }
 
+    public function testManagerCheckRecursivePath()
+    {
+        self::$rbac->Permissions->addPath('/permissions_1/permissions_2');
+        $perm_id_1 = self::$rbac->Permissions->pathId('/permissions_1/permissions_2');
+        
+        self::$rbac->Roles->addPath('/roles_1/roles_2/roles_3');
+        $role_id_1 = self::$rbac->Roles->pathId('/roles_1/roles_2/roles_3');
+        
+        self::$rbac->Roles->assign($role_id_1, $perm_id_1);
+        self::$rbac->Users->assign($role_id_1, 5);
+        
+        $result = self::$rbac->check('/permissions_1/permissions_2/permissons_3', 5, true);
+        
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @expectedException RbacPermissionNotFoundException
+     */
+    
+    public function testManagerCheckNonRecursivePath()
+    {
+        self::$rbac->Permissions->addPath('/permissions_1/permissions_2');
+        $perm_id_1 = self::$rbac->Permissions->pathId('/permissions_1/permissions_2');
+        
+        self::$rbac->Roles->addPath('/roles_1/roles_2/roles_3');
+        $role_id_1 = self::$rbac->Roles->pathId('/roles_1/roles_2/roles_3');
+        
+        self::$rbac->Roles->assign($role_id_1, $perm_id_1);
+        self::$rbac->Users->assign($role_id_1, 5);
+        
+        self::$rbac->check('/permissions_1/permissions_2/permissons_3', 5, false);
+        
+    }
+    
     public function testManagerCheckBadPermBadUserFalse()
     {
         $result = self::$rbac->check(5, 5);


### PR DESCRIPTION
This evolution allow to check/ enforce against permission that do not exist in database but parent's does.
Exemple : if user as perm '/P1/P2' check 'P1/P2/P3' will be true even if 'P1/P2/P3' is not declared in database.
#113 